### PR TITLE
DDclient dynamic DNS updater

### DIFF
--- a/ddclient.json
+++ b/ddclient.json
@@ -1,0 +1,24 @@
+{
+	"DDclient": {
+		"description": "Dynamic DNS Updater. Supports a variety of protocols.",
+		"version": "1.0.0",
+		"website": "https://hub.docker.com/r/mace/ddclient/",
+		"more_info": "Rename the sample config to ddclient.conf in the host directory. The sample config will be avaible afer the first run. Email is supported buy the docker image but is not currently supported in this rock-on.",
+		"containers": {
+			"ddclient": {
+				"image": "mace/ddclient",
+				"launch_order": 1,
+				"volumes": {
+					"/config": {
+						"description": "Location of config",
+						"label": "Config"
+					}
+				},
+				"opts": [
+					["--net", "bridge"],
+					["-v", "/etc/localtime:/etc/localtime:ro"]
+				]
+			}
+		}
+	}
+}

--- a/ddclient.json
+++ b/ddclient.json
@@ -3,7 +3,7 @@
 		"description": "Dynamic DNS Updater. Supports a variety of protocols.",
 		"version": "1.0.0",
 		"website": "https://hub.docker.com/r/mace/ddclient/",
-		"more_info": "Rename the sample config to ddclient.conf in the host directory. The sample config will be avaible afer the first run. Email is supported buy the docker image but is not currently supported in this rock-on.",
+		"more_info": "Rename the sample config to ddclient.conf in the host directory. The sample config will be avaible afer the first run. Email is supported by the docker image but is not currently supported in this rock-on.",
 		"containers": {
 			"ddclient": {
 				"image": "mace/ddclient",


### PR DESCRIPTION
Software: https://sourceforge.net/p/ddclient/wiki/Home/ 
Image: https://hub.docker.com/r/mace/ddclient/ which seems to be the most popular image.

Configuration is a bit akward, you have to give it a volume, run it once to let it generate a sample config, then rename and edit that, and then either restart the image or wait a few minutes. But it does work, and can be extended to have a few other features such as email.

(I tried a [different](https://hub.docker.com/r/yaronr/ddclient/) docker image that appeared to have a simpler config, just dump all the params on the command line in a pre-defined order without even specifying param names.. but I couldn't get that to play nice with rockstor.)